### PR TITLE
Don't write a compiled.py file per default, refactoring, added a --out parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,27 @@ nerd — math
 ```
 
 ## OMG!! this looks so exciting! How do I start?
-The Gyatt compiler(`gyatt.py`) is written in Python, and therefore, you will need [Python](https://www.python.org/) to run Gyatt. Next, clone this repository. Then, write some gyatt code or use the example `code.gyt` file provided and run `python3 gyatt.py code.gyt`. This will compile the `compiled.py` version of your `.gyt` code, which can be found in your working directory. WARNING: THIS WILL DELETE PRE-EXSTING `compiled.py` CODE AT RUNTIME, SO MAKE SURE YOU DON'T HAVE ANY CONFLICTS. 
+The Gyatt compiler(`gyatt.py`) is written in Python, and therefore, you will need [Python](https://www.python.org/) to run Gyatt. Next, clone this repository. Then, write some gyatt code or use the example `code.gyt` file provided and run `python3 gyatt.py code.gyt`. This will compile and execute the `.gyt` code.
 
-More advanced users can also add `gyatt` as an alias for `python3 gyatt.py` in their terminal settings so they can run Gyatt code more easily—`gyatt code.gyt`. 
+### <u>Advanced</u> Usage
+```
+usage: gyatt.py [-h] [-o PATH] file
+
+positional arguments:
+  file
+
+options:
+  -h, --help           show this help message and exit
+  -o PATH, --out PATH  Compile and save the code into a Python script at PATH
+```
+
+Even more advanced users can also add `gyatt` as an alias for `python3 gyatt.py` in their terminal settings so they can run Gyatt code more easily—`gyatt code.gyt`.
 
 ## Future changes (not happening)
+
 1. Add more Gyatt replacements
 2. Automatically add alias
 3. ~~Add tokenization~~
+4. Get some help
 
 # Yes, I am okay.

--- a/gyatt.py
+++ b/gyatt.py
@@ -60,7 +60,8 @@ if __name__ == "__main__":
     with args.file as gyatt:
         python_code = interpret(gyatt.read())
         if args.out is not None:
-            with open(args.out, "x") as py:
+            with open(args.out, "w") as py:
+                py.truncate(0)
                 py.write(python_code)
         else:
             exec(python_code)

--- a/gyatt.py
+++ b/gyatt.py
@@ -1,13 +1,8 @@
 import re
 import argparse
-import os
 import tokenize
 import io
 import untokenize
-
-if os.path.exists("compiled.py"):
-    os.remove("compiled.py")
-
 
 gyatt_slang = {
     "lrizz": "False",
@@ -42,17 +37,8 @@ gyatt_slang = {
     "nerd": "math",
 }
 
-parser = argparse.ArgumentParser()
-parser.add_argument("file", type=argparse.FileType("r"))
-args = parser.parse_args()
-
-
-def run(runfile):
-    with open(runfile, "r") as rnf:
-        exec(rnf.read())
-
-
-def interpret(gyatt_code):
+def interpret(gyatt_code: str) -> str:
+    assert type(gyatt_code) == str
     tokens = list(tokenize.generate_tokens(io.StringIO(gyatt_code).readline))
     python_code = ""
     for i, token in enumerate(tokens):
@@ -64,9 +50,17 @@ def interpret(gyatt_code):
     return python_code
 
 
-with args.file as gyatt:
-    python_code = interpret(gyatt.read())
-    with open("compiled.py", "x") as py:
-        py.write(python_code)
-
-run("compiled.py")
+if __name__ == "__main__":
+    # Parse commandline arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", type=argparse.FileType("r"))
+    parser.add_argument("-o", "--out", type=str, metavar="PATH", help="Compile and save the code into a Python script at PATH")
+    args = parser.parse_args()
+    # Interpret & execute the code
+    with args.file as gyatt:
+        python_code = interpret(gyatt.read())
+        if args.out is not None:
+            with open(args.out, "x") as py:
+                py.write(python_code)
+        else:
+            exec(python_code)


### PR DESCRIPTION
&nbsp;
&nbsp;
&nbsp;
&nbsp;
&nbsp;
&nbsp;
:)
&nbsp;
&nbsp;
```
usage: gyatt.py [-h] [-o PATH] file

positional arguments:
  file

options:
  -h, --help           show this help message and exit
  -o PATH, --out PATH  Compile and save the code into a Python script at PATH
```
&nbsp;
&nbsp;