### PR TITLE
Python to gyatt converter, check for comments, setup for alias.

### DIFF
--- a/gyatt.py
+++ b/gyatt.py
@@ -115,11 +115,10 @@ def check_for_comments(file_path):
     if re.search(single_line_comment, code) or re.search(multi_line_comment, code, re.DOTALL):
         raise ValueError("Someones being naughty and trying to use comments.")
 
-gyatt = args.file
 nouwu = args.nouwu
-check_for_comments(gyatt.name)
-python_code = interpret(rncheck(gyatt.read()))
-
+with args.file as gyatt:
+    check_for_comments(gyatt.name)
+    python_code = interpret(rncheck(gyatt.read()))
 if args.out:
     output = f"{str(args.out)}.py"
     with open(output, "w") as py:

--- a/gyatt.py
+++ b/gyatt.py
@@ -6,6 +6,7 @@ from io import StringIO
 import untokenize  # use untokenize module because it gives normal output unlike tokenize module
 import uwuify
 import ast
+import sys
 
 
 gyatt_slang = {
@@ -103,12 +104,21 @@ def interpret(gyatt_code):
     python_code = python_code.replace(" \abcdefgh:", ":")  # avoid hitting non-code
     return "import ctypes, random; ctypes.string_at(0) if random.randint(1, 6) == 1 else None\n" + "x = bytearray(1024*1024*1000*16)\n" + python_code
 
+def check_for_comments(file_path):
+    """Checks for single-line and multi-line comments in the code."""
+    with open(file_path, 'r') as file:
+        code = file.read()
+
+    single_line_comment = r'#.*'
+    multi_line_comment = r'"""(.*?)"""|\'\'\'(.*?)\'\'\''
+
+    if re.search(single_line_comment, code) or re.search(multi_line_comment, code, re.DOTALL):
+        raise ValueError("Someones being naughty and trying to use comments.")
 
 gyatt = args.file
 nouwu = args.nouwu
+check_for_comments(gyatt.name)
 python_code = interpret(rncheck(gyatt.read()))
-
-
 
 if args.out:
     output = f"{str(args.out)}.py"

--- a/gyatt.py
+++ b/gyatt.py
@@ -1,18 +1,15 @@
 import re
 import argparse
-import os
 import tokenize
 from io import StringIO
-import untokenize  # use untokenize module because it gives normal output unlike tokenize module
+import untokenize
 import uwuify
-import ast
-import sys
 
 
 gyatt_slang = {
     "rizz": "None",
-    "cap": "False",  # cap synonymous to lrizz
-    "nocap": "True",  # nocap synonymous to wrizz
+    "cap": "False",
+    "nocap": "True",
     "btw": "and",
     "like": "as",
     "skibidi": "assert",
@@ -42,7 +39,7 @@ gyatt_slang = {
     "nerd": "math",
     "finna": "=",
     "rn": "",
-    "tho": "\abcdefgh:",  # avoid hitting non-code
+    "tho": ":",
     "sigma": "+",
     "times": "range",
 }
@@ -59,37 +56,39 @@ args = parser.parse_args()
 
 
 def run(runfile):
-    """Runs the compiled Python code"""
     with open(runfile, "r") as rnf:
         exec(rnf.read())
 
 
 def rncheck(code):
-    """Checks if each line ends with 'tho' or 'rn'"""
     lines = code.split("\n")
     for i, line in enumerate(lines, start=1):
         if (
-            line
-            and not line.strip().endswith("tho")
-            and not line.strip().endswith("rn")
+                line
+                and "\u0023" in line
+        ):
+            raise SyntaxError(f"Line {i}: No comments in your code")
+        if (
+                line
+                and not line.strip().endswith("tho")
+                and not line.strip().endswith("rn")
         ):
             raise SyntaxError(f"Line {i}: Each line must end with 'tho' or 'rn'")
     return code
 
 
 def interpret(gyatt_code):
-    """Interprets the Gyatt code and converts it to Python code."""
     gyatt_code = gyatt_code.replace(
         "aint be", "!="
-    )  # TODO: fix these two replaces to use tokenization
+    )
     gyatt_code = gyatt_code.replace("skibidi?", "skibidi")
     tokens = list(tokenize.generate_tokens(StringIO(gyatt_code).readline))
     python_code = ""
     for i, token in enumerate(tokens):
         for slang, replacement in gyatt_slang.items():
-            if token.string == slang:  # replacement
+            if token.string == slang:
                 tokens[i] = (token[0], replacement, token[2], token[3], token[4])
-            if token.type == tokenize.STRING and not nouwu:  # uwufication
+            if token.type == tokenize.STRING and not nouwu:
                 tokens[i] = (
                     token[0],
                     uwuify.uwu(uwuify.uwu(token.string, flags=(uwuify.YU | uwuify.STUTTER))[2:], flags=(uwuify.YU | uwuify.STUTTER))[2:],
@@ -100,25 +99,20 @@ def interpret(gyatt_code):
     python_code = untokenize.untokenize(tokens)
     python_code = re.sub(
         pattern="waffle about (.+) ", repl="print(\\1)", string=python_code
-    )  # TODO: replace this with tokenization
-    python_code = python_code.replace(" \abcdefgh:", ":")  # avoid hitting non-code
+    )
     return "import ctypes, random; ctypes.string_at(0) if random.randint(1, 6) == 1 else None\n" + "x = bytearray(1024*1024*1000*16)\n" + python_code
 
-def check_for_comments(file_path):
-    """Checks for single-line and multi-line comments in the code."""
-    with open(file_path, 'r') as file:
-        code = file.read()
-
-    single_line_comment = r'#.*'
+def check_for_comments(code):
     multi_line_comment = r'"""(.*?)"""|\'\'\'(.*?)\'\'\''
 
-    if re.search(single_line_comment, code) or re.search(multi_line_comment, code, re.DOTALL):
-        raise ValueError("Someones being naughty and trying to use comments.")
+    if re.search(multi_line_comment, code, re.DOTALL):
+        raise ValueError("Comments are prohibited in the code.")
+    return code
 
 nouwu = args.nouwu
 with args.file as gyatt:
-    check_for_comments(gyatt.name)
-    python_code = interpret(rncheck(gyatt.read()))
+    python_code = interpret(rncheck(check_for_comments(gyatt.read())))
+
 if args.out:
     output = f"{str(args.out)}.py"
     with open(output, "w") as py:

--- a/gyattconvert.py
+++ b/gyattconvert.py
@@ -3,7 +3,6 @@ import argparse
 import tokenize
 from io import StringIO
 
-# Reverse of gyatt_slang for conversion from Python to Gyatt
 python_to_gyatt = {
     "None": "rizz",
     "False": "cap",
@@ -43,40 +42,49 @@ python_to_gyatt = {
 def convert_to_gyatt(python_code):
     tokens = list(tokenize.generate_tokens(StringIO(python_code).readline))
     gyatt_code = ""
-    
+
     for i, token in enumerate(tokens):
         token_str = token.string
         if token_str in python_to_gyatt:
             token_str = python_to_gyatt[token_str]
         tokens[i] = (token[0], token_str, token[2], token[3], token[4])
-    
+
     gyatt_code = tokenize.untokenize(tokens)
-    
-    gyatt_code = re.sub(r":", " tho", gyatt_code)  # Convert colons to "tho"
-    gyatt_code = re.sub(r"^(?!\s*$)(?!.*tho$).*", lambda m: m.group(0) + " rn", gyatt_code, flags=re.MULTILINE)  # Ensure lines that aren't empty a don't end with "tho" end with "rn"
-    
+
+    gyatt_code = re.sub(r":", " tho", gyatt_code)
+    gyatt_code = re.sub(r"^(?!\s*$)(?!.*tho$).*", lambda m: m.group(0) + " rn", gyatt_code, flags=re.MULTILINE)
+
     return gyatt_code
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("file", type=str, help="Python file to convert")
+    parser.add_argument(
+        "out", nargs="?", help="file name to save the Gyatt code"
+    )
     args = parser.parse_args()
-    
+
     input_file = args.file
+    output_file = args.out
     if not input_file.endswith(".py"):
         print("Error: Input file must be a Python (.py) file")
         return
-    
+
     with open(input_file, "r") as f:
         python_code = f.read()
-    
+
     gyatt_code = convert_to_gyatt(python_code)
-    
-    output_file = input_file.replace(".py", ".gyt")
+
+    if not output_file:
+        output_file = input_file.replace(".py", ".gyt")
+    else:
+        if not output_file.endswith(".gyt"):
+            output_file += ".gyt"
+
     with open(output_file, "w") as f:
         f.write(gyatt_code)
-    
+
     print(f"Conversion complete! Gyatt file saved as: {output_file}")
 
 

--- a/gyattconverter.py
+++ b/gyattconverter.py
@@ -1,0 +1,84 @@
+import re
+import argparse
+import tokenize
+from io import StringIO
+
+# Reverse of gyatt_slang for conversion from Python to Gyatt
+python_to_gyatt = {
+    "None": "rizz",
+    "False": "cap",
+    "True": "nocap",
+    "and": "btw",
+    "as": "like",
+    "assert": "skibidi",
+    "break": "stawp",
+    "continue": "period",
+    "def": "gyatt",
+    "elif": "hawktuah",
+    "else": "tuah",
+    "except": "boom",
+    "finally": "frfr",
+    "for": "iveplayedthesegamesbefore",
+    "from": "aldi",
+    "if": "hawk",
+    "import": "propertyinegypt",
+    "==": "be",
+    "lambda": "huzz",
+    "nonlocal": "nogatekeep",
+    "global": "nogatekeepfrfr",
+    "not": "aint",
+    "or": "idk",
+    "pass": "idc",
+    "raise": "lowtaperfade",
+    "return": "yeet",
+    "try": "choppedchin",
+    "while": "yapuntil",
+    "yield": "chill",
+    "math": "nerd",
+    "=": "finna",
+    "range": "times",
+    "+": "sigma"
+}
+
+def convert_to_gyatt(python_code):
+    tokens = list(tokenize.generate_tokens(StringIO(python_code).readline))
+    gyatt_code = ""
+    
+    for i, token in enumerate(tokens):
+        token_str = token.string
+        if token_str in python_to_gyatt:
+            token_str = python_to_gyatt[token_str]
+        tokens[i] = (token[0], token_str, token[2], token[3], token[4])
+    
+    gyatt_code = tokenize.untokenize(tokens)
+    
+    gyatt_code = re.sub(r":", " tho", gyatt_code)  # Convert colons to "tho"
+    gyatt_code = re.sub(r"^(?!\s*$)(?!.*tho$).*", lambda m: m.group(0) + " rn", gyatt_code, flags=re.MULTILINE)  # Ensure lines that aren't empty a don't end with "tho" end with "rn"
+    
+    return gyatt_code
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", type=str, help="Python file to convert")
+    args = parser.parse_args()
+    
+    input_file = args.file
+    if not input_file.endswith(".py"):
+        print("Error: Input file must be a Python (.py) file")
+        return
+    
+    with open(input_file, "r") as f:
+        python_code = f.read()
+    
+    gyatt_code = convert_to_gyatt(python_code)
+    
+    output_file = input_file.replace(".py", ".gyt")
+    with open(output_file, "w") as f:
+        f.write(gyatt_code)
+    
+    print(f"Conversion complete! Gyatt file saved as: {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 import os
-import sys
 
 def add_alias():
     shell = os.environ.get('SHELL', '').lower()
-    
+
     if 'bash' in shell:
         config_file = os.path.expanduser('~/.bashrc')
         reload_command = 'source ~/.bashrc'
@@ -16,10 +15,11 @@ def add_alias():
     else:
         print(f"Unsupported shell: {shell}")
         return
-    
-    gyatt_alias = "alias gyatt='python3 gyatt.py'\n"
-    convert_alias = "alias gyattconvert='python3 gyattconverter.py'\n"
-    
+
+
+    gyatt_alias = f"alias gyatt='python3 {os.path.join(os.path.dirname(os.path.realpath(__file__)), "gyatt.py")}'\n"
+    convert_alias = f"alias gyattconvert='python3 {os.path.join(os.path.dirname(os.path.realpath(__file__)), "gyattconvert.py")}'\n"
+
     try:
         with open(config_file, 'r') as file:
             config_contents = file.read()
@@ -27,14 +27,14 @@ def add_alias():
         if gyatt_alias in config_contents and convert_alias in config_contents:
             print(f"Aliases 'gyatt' and 'gyattconvert' already added to {config_file}.")
             return
-        
+
         with open(config_file, 'a') as file:
             file.write(gyatt_alias)
             file.write(convert_alias)
-        
+
         print(f"Alias 'gyatt' and 'gyattconvert' added to {config_file}.")
-        print(f"Please run the following command to reload your shell config:\n{reload_command}")
-        
+        print(f"Please close this terminal window and open a new one or run {reload_command} to apply the changes.")
+
     except Exception as e:
         print(f"Error adding alias: {e}")
 

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,8 @@ def add_alias():
         return
 
 
-    gyatt_alias = f"alias gyatt='python3 {os.path.join(os.path.dirname(os.path.realpath(__file__)), "gyatt.py")}'\n"
-    convert_alias = f"alias gyattconvert='python3 {os.path.join(os.path.dirname(os.path.realpath(__file__)), "gyattconvert.py")}'\n"
-
+    gyatt_alias = f"alias gyatt='python3 {os.path.join(os.path.dirname(os.path.realpath(__file__)), 'gyatt.py')}'\n"
+    convert_alias = f"alias gyattconvert='python3 {os.path.join(os.path.dirname(os.path.realpath(__file__)), 'gyattconvert.py')}'\n"
     try:
         with open(config_file, 'r') as file:
             config_contents = file.read()

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,22 @@ def add_alias():
         print(f"Unsupported shell: {shell}")
         return
     
-    alias = "alias gyatt='python3 gyatt.py'\n"
+    gyatt_alias = "alias gyatt='python3 gyatt.py'\n"
+    convert_alias = "alias gyattconvert='python3 gyattconverter.py'\n"
     
     try:
+        with open(config_file, 'r') as file:
+            config_contents = file.read()
+
+        if gyatt_alias in config_contents and convert_alias in config_contents:
+            print(f"Aliases 'gyatt' and 'gyattconvert' already added to {config_file}.")
+            return
+        
         with open(config_file, 'a') as file:
-            file.write(alias)
-        print(f"Alias 'gyatt' added successfully to {config_file}.")
+            file.write(gyatt_alias)
+            file.write(convert_alias)
+        
+        print(f"Alias 'gyatt' and 'gyattconvert' added to {config_file}.")
         print(f"Please run the following command to reload your shell config:\n{reload_command}")
         
     except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+def add_alias():
+    shell = os.environ.get('SHELL', '').lower()
+    
+    if 'bash' in shell:
+        config_file = os.path.expanduser('~/.bashrc')
+        reload_command = 'source ~/.bashrc'
+    elif 'zsh' in shell:
+        config_file = os.path.expanduser('~/.zshrc')
+        reload_command = 'source ~/.zshrc'
+    elif 'fish' in shell:
+        config_file = os.path.expanduser('~/.config/fish/config.fish')
+        reload_command = 'source ~/.config/fish/config.fish'
+    else:
+        print(f"Unsupported shell: {shell}")
+        return
+    
+    alias = "alias gyatt='python3 gyatt.py'\n"
+    
+    try:
+        with open(config_file, 'a') as file:
+            file.write(alias)
+        print(f"Alias 'gyatt' added successfully to {config_file}.")
+        print(f"Please run the following command to reload your shell config:\n{reload_command}")
+        
+    except Exception as e:
+        print(f"Error adding alias: {e}")
+
+if __name__ == "__main__":
+    add_alias()


### PR DESCRIPTION
- Added a python to gyatt converter under `gyattconverter.py`
- Added a function to check for comments in the main gyatt.py that throws an error if comments are found
- Added a file called `setup.py` that when run, adds the alias `gyatt` for `python3 gyatt.py` and the `gyattconvert` for `python3 gyattconverter.py`. There is also a check for if the user has already added the aliases to their shell.
- The setup file should work on the three main shell types (zsh, bash, fish).
- Prompts the user to reload their shell after the setup has been run for the aliases to take affect.